### PR TITLE
Improve SpiderLauncher

### DIFF
--- a/GRID_LRT/application/submit.py
+++ b/GRID_LRT/application/submit.py
@@ -379,9 +379,9 @@ class SpiderLauncher(JdlLauncher):
             raise IOError("Launch file doesn't exist! "+self.launch_file)
         slurmfile = '#!/usr/bin/env bash\n'
         if self.wholenodes:
-            slurmfile += '#SBATCH --exclusive --nodes=1 --ntasks 1--cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
+            slurmfile += '#SBATCH --exclusive --nodes=1 --ntasks 1--cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d} --output=spiderjob-%A_%a.out --error=spiderjob-%A_%a.err\n'
         else:
-            slurmfile += '#SBATCH --nodes=1 --ntasks 1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
+            slurmfile += '#SBATCH --nodes=1 --ntasks 1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d} --output=spiderjob-%A_%a.out --error=spiderjob-%A_%a.err\n'
         slurmfile += """
 echo Job landed on $(hostname)
 JOBDIR=$(mktemp -d -p $TMPDIR)

--- a/GRID_LRT/application/submit.py
+++ b/GRID_LRT/application/submit.py
@@ -340,7 +340,7 @@ class SpiderLauncher(JdlLauncher):
         self.numjobs = numjobs
         self.parameter_step = parameter_step
         self.token_type = token_type
-        self.wholenodes = 'false'
+        self.wholenodes = False
 
         if 'wholenode' in kwargs:
             self.wholenodes = kwargs['wholenode']
@@ -349,7 +349,7 @@ class SpiderLauncher(JdlLauncher):
         else:
             self.ncpu = 1
         if self.ncpu == 0:
-            self.wholenodes = 'true'
+            self.wholenodes = True
         if "queue" in kwargs:
             self.queue = kwargs['queue']
         else:
@@ -379,9 +379,9 @@ class SpiderLauncher(JdlLauncher):
             raise IOError("Launch file doesn't exist! "+self.launch_file)
         slurmfile = '#!/usr/bin/env bash\n'
         if self.wholenodes:
-            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
+            slurmfile += '#SBATCH --exclusive --nodes=1 --ntasks 1--cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
         else:
-            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
+            slurmfile += '#SBATCH --nodes=1 --ntasks 1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
         slurmfile += """
 echo Job landed on $(hostname)
 JOBDIR=$(mktemp -d -p $TMPDIR)

--- a/GRID_LRT/application/submit.py
+++ b/GRID_LRT/application/submit.py
@@ -379,9 +379,9 @@ class SpiderLauncher(JdlLauncher):
             raise IOError("Launch file doesn't exist! "+self.launch_file)
         slurmfile = '#!/usr/bin/env bash'
         if self.wholenodes:
-            slurmfile += '#SBATCH --exclusive --job-name=prefactor --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
+            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
         else:
-            slurmfile += '#SBATCH --job-name=prefactor --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
+            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
         slurmfile += """
 echo Job landed on $(hostname)
 JOBDIR=$(mktemp -d -p $TMPDIR)

--- a/GRID_LRT/application/submit.py
+++ b/GRID_LRT/application/submit.py
@@ -335,7 +335,7 @@ class SpiderLauncher(JdlLauncher):
         else: 
 	        self.__check_authorized()
         if numjobs < 1:
-            logging.warn("jdl_file with zero jobs!")
+            logging.warn("Slurm file with zero jobs!")
             numjobs = 1
         self.numjobs = numjobs
         self.parameter_step = parameter_step
@@ -379,9 +379,9 @@ class SpiderLauncher(JdlLauncher):
             raise IOError("Launch file doesn't exist! "+self.launch_file)
         slurmfile = '#!/usr/bin/env bash'
         if self.wholenodes:
-            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
+            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}'
         else:
-            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s}'
+            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}'
         slurmfile += """
 echo Job landed on $(hostname)
 JOBDIR=$(mktemp -d -p $TMPDIR)
@@ -391,7 +391,9 @@ echo Created job directory $JOBDIR
 cd $JOBDIR
 {launcher:s} {db:s} {usr:s} {pw:s} {tt:s}
 """.format(ncpu=int(self.ncpu),
-        queueu=str(self.queue)
+        queueu=str(self.queue),
+        njobs=self.numjobs,
+        concurrent=self.parameter_step,
         launcher=str(self.launch_file),
         db=str(database),
         usr=str(creds.user),

--- a/GRID_LRT/application/submit.py
+++ b/GRID_LRT/application/submit.py
@@ -377,11 +377,11 @@ class SpiderLauncher(JdlLauncher):
             database = creds.database
         if not os.path.exists(self.launch_file):
             raise IOError("Launch file doesn't exist! "+self.launch_file)
-        slurmfile = '#!/usr/bin/env bash'
+        slurmfile = '#!/usr/bin/env bash\n'
         if self.wholenodes:
-            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}'
+            slurmfile += '#SBATCH --exclusive --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
         else:
-            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}'
+            slurmfile += '#SBATCH --nodes=1 --cpus-per-task={ncpu:d} -p {queue:s} --array 1-{njobs:d}%{concurrent:d}\n'
         slurmfile += """
 echo Job landed on $(hostname)
 JOBDIR=$(mktemp -d -p $TMPDIR)
@@ -390,7 +390,8 @@ export JOBDIR
 echo Created job directory $JOBDIR
 cd $JOBDIR
 {launcher:s} {db:s} {usr:s} {pw:s} {tt:s}
-""".format(ncpu=int(self.ncpu),
+"""
+	slurmfile = slurmfile.format(ncpu=int(self.ncpu),
         queueu=str(self.queue),
         njobs=self.numjobs,
         concurrent=self.parameter_step,


### PR DESCRIPTION
More parameters have been translated to Slurm:
* `wholenodes` gets translated to the `--exclusive` flag
* `parameter_step` is handled through job arrays
* default queue set to Spider's `normal` queue

The whole thing should now also actually function.